### PR TITLE
fix typo

### DIFF
--- a/server/api/owner.js
+++ b/server/api/owner.js
@@ -1,7 +1,7 @@
 const router = require('express').Router()
 const {User, Queue, Business, Reservation} = require('../db/models')
 const {loginRequired} = require('../utils')
-const Sequelize = require('Sequelize')
+const Sequelize = require('sequelize')
 const Op = Sequelize.Op
 module.exports = router
 


### PR DESCRIPTION
require('Sequelize') -> require('sequelize') causing build errors